### PR TITLE
Fix for removing interests before creating interests from patch

### DIFF
--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -12,17 +12,14 @@ class Api::V1::UsersController < ApplicationController
 
   def update
     user = User.find_by(id: params[:id].to_i)
-    if user.update(user_params)
-      params[:interests].each do |interest|
-        if user.interests.include?(interest) == false
-          db_interest = Interest.find_by(interest_name: interest)
-          UserInterest.create!(user_id: user.id, interest_id: db_interest.id)
-        end
-      end
-      render json: UserSerializer.one_user(user)
-    else
-      render json: { status: 400, message: "Unable to update user" }
+    user.reset_interests
+
+    params[:interests].each do |interest|
+      db_interest = Interest.find_by(interest_name: interest)
+      new_interest = UserInterest.create!(user_id: user.id, interest_id: db_interest.id)
+      user.interests << db_interest
     end
+    render json: UserSerializer.one_user(user)
   end
 
   private

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -17,6 +17,9 @@ class User < ApplicationRecord
   has_many :convos_b, class_name: "Conversation", foreign_key: "user_b_id"
   has_many :user_as, through: :convos_b, source: :user_a
 
+  def reset_interests
+    self.interests.destroy_all
+  end
 
   def all_conversations
         all_convos = []


### PR DESCRIPTION
Co-Authored-By: Lauralyn Watson <lswatson16@users.noreply.github.com>
Co-Authored-By: Gunnar <gunnar.l.sorensen@gmail.com>

# Description

1. Why Did We Change This? Needed to remove existing interests before resetting them with the patch request.
2. What Changed? (Non-Technical explanation) Added logic to delete existing interests for the user.
3. Quality Assurance Steps

## List any issues this closes


## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor
- [ ] Documentation update
- [ ] Testing

## Check the correct box

- [X] This broke nothing
- [ ] This broke some stuff
- [ ] This broke everything

## Checklist:

- [ ] I have linked the appropriate Project Board in this PR
- [X] My code follows the style guidelines of this project
- [X] My code has no unused/commented out code
- [X] I have performed a self-review of my code
- [ ] I have fully tested my code
